### PR TITLE
Handle auth for elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Framework writes its configuration and stores crawled data to ElasticSearch. Bef
 
 Crawling Framework is a Java lib which will have to be extended to run Storm Crawler topology, thus Java (JDK8, Maven) infrastructure will be needed. 
 
+### Using password protected ElasticSearch
+
+Some providers hide ElasticSearch under authentification step (Which makes sense). Just set environment variables `ES_USERNAME` and `ES_PASSWORD` accordingly, everything else can remain the same. Authentification step will be done implicitly if proper credentials are there
+
 ## Configuring and Running a crawl
 
 See [Crawling Framework Example](https://github.com/tokenmill/crawling-framework-example) project's documentation.

--- a/elasticsearch/src/main/java/lt/tokenmill/crawling/es/ElasticConnection.java
+++ b/elasticsearch/src/main/java/lt/tokenmill/crawling/es/ElasticConnection.java
@@ -59,7 +59,7 @@ public class ElasticConnection {
         public CredentialsProvider getCredentials(){
             this.credentialsProvider.setCredentials(
                     AuthScope.ANY,
-                    new UsernamePasswordCredentials("user", "password")
+                    new UsernamePasswordCredentials(this.username, this.password)
             );
 
             return this.credentialsProvider;

--- a/elasticsearch/src/main/java/lt/tokenmill/crawling/es/ElasticConnection.java
+++ b/elasticsearch/src/main/java/lt/tokenmill/crawling/es/ElasticConnection.java
@@ -53,7 +53,7 @@ public class ElasticConnection {
         }
 
         public boolean hasCredentials(){
-            return !this.username.isEmpty() && !this.password.isEmpty();
+            return this.username != null && this.password != null;
         }
 
         public CredentialsProvider getCredentials(){
@@ -140,6 +140,7 @@ public class ElasticConnection {
         ESCredentials credentials = new ESCredentials();
         RestClientBuilder restClient = RestClient.builder(new HttpHost(hostname, restPort, restScheme));
         if(credentials.hasCredentials()) {
+            LOG.info("Found credentials. Applying");
             restClient.setHttpClientConfigCallback(b -> b.setDefaultCredentialsProvider(credentials.getCredentials()));
         }
 


### PR DESCRIPTION
If credentials are given in environment variables: `ES_USERNAME` and `ES_PASSWORD`, create basic CredentialsProvider and apply it. Should cover basic cases of ES auth