### PR TITLE
Redis module for cache

### DIFF
--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>crawling-framework</artifactId>
+        <groupId>lt.tokenmill.crawling</groupId>
+        <version>0.3.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cache</artifactId>
+
+    <properties>
+        <jackson.version>2.11.1</jackson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>3.3.0</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-objects</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.14</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/CacheConstants.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/CacheConstants.java
@@ -1,0 +1,7 @@
+package lt.tokenmill.crawling.cache;
+
+public class CacheConstants {
+    public static final String REDIS_HOST = "cache.redis.host";
+    public static final String REDIS_PORT = "cache.redis.port";
+    public static final String REDIS_AUTH = "cache.redis.auth";
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/datamodel/Pair.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/datamodel/Pair.java
@@ -1,0 +1,29 @@
+package lt.tokenmill.crawling.cache.datamodel;
+
+public class Pair<T, U> {
+    private final T key;
+    private final U value;
+    public Pair(T key, U value){
+        this.key = key;
+        this.value = value;
+    }
+
+    public T getKey(){
+        return key;
+    }
+
+    public U getValue(){
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if(other instanceof Pair){
+            Pair<T, U> otherPair = (Pair<T, U>)other;
+
+            return key.equals(otherPair.getKey()) && value.equals(otherPair.getValue());
+        }
+
+        return false;
+    }
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/providers/CacheProvider.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/providers/CacheProvider.java
@@ -1,0 +1,29 @@
+package lt.tokenmill.crawling.cache.providers;
+
+import lt.tokenmill.crawling.cache.datamodel.Pair;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public interface CacheProvider {
+    <T> CompletableFuture<Boolean> set(String namespace, String key, T value);
+    <T> CompletableFuture<Boolean> setMultiple(String namespace, Set<Pair<String, T>> pairs);
+
+    CompletableFuture<Boolean> addKey(String namespace, String key);
+    CompletableFuture<Boolean> addKeyMultiple(String namespace, Collection<String> keys);
+    CompletableFuture<Boolean> removeKey(String namespace, String key);
+    CompletableFuture<Boolean> moveKey(String source, String dest, String key);
+    CompletableFuture<String> findKey(String namespace, String key);
+
+    <T> CompletableFuture<T> get(Class<T> klass, String namespace, String key);
+    <T> CompletableFuture<Set<T>> getMultiple(Class<T> klass, String namespace, String... keys);
+    <T> CompletableFuture<Set<T>> getMultiple(Class<T> klass, String namespace, Collection<String> keys);
+
+    CompletableFuture<Boolean> contains(String key);
+    CompletableFuture<Boolean> contains(String namespace, String key);
+
+    CompletableFuture<Set<String>> keysInNamespace(String namespace);
+
+    void cleanup();
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/Builder.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/Builder.java
@@ -1,0 +1,51 @@
+package lt.tokenmill.crawling.cache.providers.redis;
+
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
+
+import java.util.Optional;
+
+public class Builder{
+    private String host = "localhost";
+    private int port = 6379;
+    private Optional<String> auth = Optional.empty();
+    private int timeout = Protocol.DEFAULT_TIMEOUT;
+
+    public Builder withHost(String host){
+        this.host = host;
+        return this;
+    }
+
+    public Builder withPort(int port){
+        this.port = port;
+        return this;
+    }
+
+    public Builder withAuth(String auth){
+        if(auth != null) {
+            this.auth = Optional.of(auth);
+        }
+        return this;
+    }
+
+    public Builder withTimeoutMillis(int millis){
+        this.timeout = millis;
+        return this;
+    }
+
+    public RedisProvider build(){
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMaxTotal(100);
+        JedisPool pool;
+        if(auth.isPresent()){
+            pool = new JedisPool(config, host, port, timeout, auth.get());
+        }
+        else{
+            pool = new JedisPool(config, host, port, timeout);
+        }
+
+        return new RedisProvider(pool);
+    }
+
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/RedisKVProvider.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/RedisKVProvider.java
@@ -1,0 +1,85 @@
+package lt.tokenmill.crawling.cache.providers.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lt.tokenmill.crawling.cache.datamodel.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Pipeline;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class RedisKVProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(RedisKVProvider.class);
+    private final RedisResourceProvider resource;
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    public RedisKVProvider(RedisResourceProvider resourceProvider){
+        this.resource = resourceProvider;
+    }
+
+    public CompletableFuture<Boolean> contains(String namespace, String key) {
+        return resource.withJedis(redis -> redis.hexists(namespace, key));
+    }
+
+    public <T> CompletableFuture<Boolean> set(String namespace, String key, T value) {
+        return resource.withJedis(redis -> {
+            try {
+                redis.hset(namespace, key, objectMapper.writeValueAsString(value));
+                return true;
+            }
+            catch (Exception ex){
+                LOG.error("Failed to set value", ex);
+                return false;
+            }
+        });
+    }
+
+    public <T> CompletableFuture<Boolean> setMultiple(String namespace, Set<Pair<String, T>> pairs){
+        return resource.withJedis(redis -> {
+            Pipeline pipe = redis.pipelined();
+            pipe.multi();
+            for(Pair<String, T> pair : pairs){
+                try {
+                    pipe.hset(namespace, pair.getKey(), objectMapper.writeValueAsString(pair.getValue()));
+                }
+                catch (Exception ex){
+                    LOG.error("Failed to set value", ex);
+                }
+            }
+
+            pipe.sync();
+            pipe.exec();
+            return true;
+        });
+    }
+
+    public <T> CompletableFuture<T> get(Class<T> klass, String namespace, String key) {
+        return resource.withJedis(redis -> {
+            String data = redis.hget(namespace, key);
+            return parseObj(data, klass);
+        });
+    }
+
+    private<T> T parseObj(String data, Class<T> klass){
+        try {
+            return objectMapper.readValue(data, klass);
+        }
+        catch(Exception ex){
+            return null;
+        }
+    }
+
+    public <T> CompletableFuture<Set<T>> getMultiple(Class<T> klass, String namespace, Set<String> keys) {
+        return resource
+                .withPipeline(pipe -> keys.stream().map(k -> pipe.hget(namespace, k)))
+                .thenApply(responses -> {
+                    return responses
+                            .map(data -> parseObj(data, klass))
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toSet());
+                });
+    }
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/RedisProvider.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/RedisProvider.java
@@ -1,0 +1,94 @@
+package lt.tokenmill.crawling.cache.providers.redis;
+
+import lt.tokenmill.crawling.cache.datamodel.Pair;
+import lt.tokenmill.crawling.cache.providers.CacheProvider;
+import redis.clients.jedis.JedisPool;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class RedisProvider implements CacheProvider {
+    private final RedisResourceProvider resourceProvider;
+    private final RedisKVProvider kvProvider;
+    private final RedisSetProvider setProvider;
+
+    protected RedisProvider(JedisPool pool){
+        this.resourceProvider = new RedisResourceProvider(pool);
+        this.kvProvider = new RedisKVProvider(resourceProvider);
+        this.setProvider = new RedisSetProvider(resourceProvider);
+    }
+
+    @Override
+    public <T> CompletableFuture<Boolean> set(String namespace, String key, T value) {
+        return kvProvider.set(namespace, key, value);
+    }
+
+    @Override
+    public <T> CompletableFuture<Boolean> setMultiple(String namespace, Set<Pair<String, T>> pairs) {
+        return kvProvider.setMultiple(namespace, pairs);
+    }
+
+
+    @Override
+    public <T> CompletableFuture<T> get(Class<T> klass, String namespace, String key) {
+        return kvProvider.get(klass, namespace, key);
+    }
+
+    @Override
+    public <T> CompletableFuture<Set<T>> getMultiple(Class<T> klass, String namespace, String... keys) {
+        return getMultiple(klass, namespace, Arrays.asList(keys));
+    }
+
+    @Override
+    public <T> CompletableFuture<Set<T>> getMultiple(Class<T> klass, String namespace, Collection<String> initialKeys) {
+        return kvProvider.getMultiple(klass, namespace, initialKeys.stream().collect(Collectors.toSet()));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> addKey(String namespace, String key) {
+        return setProvider.addKey(namespace, key);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> addKeyMultiple(String namespace, Collection<String> keys) {
+        return setProvider.addKeys(namespace, keys);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> removeKey(String namespace, String key) {
+        return setProvider.removeKey(namespace, key);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> moveKey(String source, String dest, String key) {
+        return setProvider.moveKey(source, dest, key);
+    }
+
+    @Override
+    public CompletableFuture<String> findKey(String namespace, String key) {
+        return setProvider.findKey(namespace, key);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> contains(String key) {
+        return resourceProvider.withJedis(redis -> redis.exists(key));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> contains(String namespace, String key) {
+        return kvProvider.contains(namespace, key);
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> keysInNamespace(String namespace) {
+        return setProvider.keysInNamespace(namespace);
+    }
+
+    @Override
+    public void cleanup() {
+        resourceProvider.withJedis(redis -> redis.flushAll());
+    }
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/RedisResourceProvider.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/RedisResourceProvider.java
@@ -1,0 +1,74 @@
+package lt.tokenmill.crawling.cache.providers.redis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.*;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class RedisResourceProvider {
+    private final JedisPool jedisPool;
+    private static final Logger LOG = LoggerFactory.getLogger(RedisResourceProvider.class);
+    private final static int MAX_RETRIES = 5;
+    private final static long RETRY_TIMEOUT = 300;
+
+
+    protected RedisResourceProvider(JedisPool pool){
+        this.jedisPool = pool;
+    }
+
+    public<T> CompletableFuture<T> withJedis(Function<Jedis, ? extends T> body){
+        CompletableFuture<T> future = CompletableFuture.supplyAsync(() -> {
+            int retryCount = 0;
+
+            while(true) {
+                try (Jedis jedis = jedisPool.getResource()) {
+                    T result = body.apply(jedis);
+                    if(result != null){
+                        return result;
+                    }
+                    else {
+                        return null;
+                    }
+                } catch (JedisConnectionException cex){
+                    retryCount++;
+                    if(retryCount > MAX_RETRIES) {
+                        throw cex;
+                    }
+                    else {
+                        LOG.warn("Redis operation has failed due to connection issue. Retrying in {}ms", RETRY_TIMEOUT * retryCount);
+                        try {
+                            Thread.sleep(RETRY_TIMEOUT);
+                        } catch (InterruptedException iex) {
+                            continue;
+                        }
+                    }
+
+                } catch (Exception ex) {
+                    throw ex;
+                }
+            }
+        });
+
+        return future;
+    }
+
+    public<T> CompletableFuture<Stream<T>> withPipeline(Function<Pipeline, Stream<Response<T>>> body){
+        return withJedis(redis -> {
+            Pipeline pipe = redis.pipelined();
+            pipe.multi();
+            List<Response<T>> results = body.apply(pipe).collect(Collectors.toList());
+
+            Response<List<Object>> resultsResponse = pipe.exec();
+            pipe.sync();
+
+            resultsResponse.get();
+            return results.stream().map(r -> r.get());
+        });
+    }
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/RedisSetProvider.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/providers/redis/RedisSetProvider.java
@@ -1,0 +1,154 @@
+package lt.tokenmill.crawling.cache.providers.redis;
+
+import lt.tokenmill.crawling.cache.datamodel.Pair;
+import lt.tokenmill.crawling.cache.utils.FutureUtils;
+import lt.tokenmill.crawling.cache.utils.KeyUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Response;
+import redis.clients.jedis.ScanResult;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class RedisSetProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(RedisKVProvider.class);
+    private final RedisResourceProvider resource;
+
+    public RedisSetProvider(RedisResourceProvider resourceProvider){
+        this.resource = resourceProvider;
+    }
+
+    public CompletableFuture<Boolean> addKey(String namespace, String key) {
+        return addKeys(namespace, Arrays.asList(key));
+    }
+
+    public CompletableFuture<Boolean> addKeys(String namespace, Collection<String> keys){
+        return resource.withJedis(redis -> {
+            Pipeline pipe = redis.pipelined();
+
+            pipe.multi();
+            for(String key : keys){
+                pipe.sadd(namespace, key);
+            }
+
+            pipe.exec();
+            pipe.sync();
+            return true;
+        });
+    }
+
+    public CompletableFuture<Boolean> removeKey(String namespace, String key) {
+        return resource.withJedis(redis -> {
+            Set<String> keys = KeyUtils.resolveKeys(namespace, redis);
+
+            Pipeline pipe = redis.pipelined();
+            pipe.multi();
+            List<Response<Long>> responses = keys
+                    .stream()
+                    .map(k -> pipe.srem(k, key))
+                    .collect(Collectors.toList());
+
+            pipe.exec();
+            pipe.sync();
+
+            responses.forEach(response -> response.get());
+            return true;
+        });
+    }
+
+    public CompletableFuture<Boolean> moveKey(String source, String dest, String key){
+        return resource.withJedis(redis -> redis.smove(source, dest, key) == 1);
+    }
+
+    public CompletableFuture<String> findKey(String namespace, String key){
+        return resource.withJedis(redis -> {
+            Set<String> keys = KeyUtils.resolveKeys(namespace, redis);
+
+            Pipeline pipe = redis.pipelined();
+            pipe.multi();
+            List<Pair<String, Response<Boolean>>> responses = keys
+                    .stream()
+                    .map(k -> new Pair<String, Response<Boolean>>(k, pipe.sismember(k, key)))
+                    .collect(Collectors.toList());
+
+            pipe.exec();
+            pipe.sync();
+
+            Optional<String> result = responses
+                    .stream()
+                    .filter(pair -> pair.getValue().get())
+                    .map(pair -> pair.getKey())
+                    .findFirst();
+
+            if(result.isPresent()){
+                return result.get();
+            }
+            else{
+                return "-1";
+            }
+        });
+    }
+
+    public CompletableFuture<Set<String>> keysInNamespace(String namespace) {
+        Set<String> keys = FutureUtils.tryGet(resource.withJedis(redis -> KeyUtils.resolveKeys(namespace, redis)), () -> Collections.emptySet());
+        if(keys.size() == 0){
+            return CompletableFuture.completedFuture(Collections.emptySet());
+        }
+
+        return resource
+                .withPipeline(pipe -> keys.stream().map(k -> pipe.smembers(k)))
+                .thenApply(results -> results.flatMap(Collection::stream).collect(Collectors.toSet()));
+    }
+
+    private Long countKeysInNamespaces(Collection<String> namespaces, Jedis redis){
+        Pipeline pipe = redis.pipelined();
+        pipe.multi();
+        List<Response<Long>> responses = namespaces.stream().map(k -> pipe.scard(k)).collect(Collectors.toList());
+
+        pipe.exec();
+        pipe.sync();
+
+        return responses
+                .stream()
+                .map(response -> response.get())
+                .filter(Objects::nonNull)
+                .reduce(0L, Long::sum);
+    }
+
+    public CompletableFuture<Long> countKeysInNamespace(String namespace) {
+        return resource.withJedis(redis -> {
+            Set<String> keys = redis.keys(namespace);
+            if(keys.size() == 0){
+                return 0L;
+            }
+
+            return countKeysInNamespaces(keys, redis);
+        });
+    }
+
+    public CompletableFuture<Long> countKeysInNamespaces(Collection<String> namespaces) {
+        return resource.withJedis(redis -> countKeysInNamespaces(namespaces, redis));
+    }
+
+    public CompletableFuture<Boolean> removeSet(String namespace) {
+        return resource.withJedis(redis -> {
+            String cursor = "0";
+            while(true){
+                ScanResult<String> result = redis.sscan(namespace, cursor);
+                cursor = result.getCursor();
+                List<String> members = result.getResult();
+                redis.srem(namespace, members.toArray(new String[0]));
+
+                if(cursor.equalsIgnoreCase("0")){
+                    break;
+                }
+            }
+
+            return true;
+        });
+    }
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/utils/FutureUtils.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/utils/FutureUtils.java
@@ -1,0 +1,47 @@
+package lt.tokenmill.crawling.cache.utils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+public class FutureUtils {
+    public static<T> T tryGet(Future<T> future, Callable<T> onFail){
+        try{
+            T result = future.get();
+            if(result != null){
+                return result;
+            }
+            else {
+                return onFail.call();
+            }
+        } catch (Exception ex){
+            ex.printStackTrace();
+            try {
+                return onFail.call();
+            } catch (Exception ex2){
+                ex2.printStackTrace();
+                return null;
+            }
+        }
+    }
+
+    public static<T> CompletableFuture<T> transformFuture(Future<T> future){
+        CompletableFuture<T> newFuture = new CompletableFuture<>();
+        try{
+            newFuture.complete(future.get());
+        } catch(Exception ex){
+            newFuture.completeExceptionally(ex);
+        }
+        return newFuture;
+    }
+
+    public static<T> boolean waitFor(Future<T> future){
+        try{
+            future.get();
+            return true;
+        } catch (Exception ex){
+            ex.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/utils/HashUtils.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/utils/HashUtils.java
@@ -1,0 +1,21 @@
+package lt.tokenmill.crawling.cache.utils;
+
+import org.apache.commons.codec.digest.MurmurHash3;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class HashUtils {
+    public static String hashKey(String url){
+        // MurmurHash64
+        return String.valueOf(MurmurHash3.hash128x64(url.getBytes())[0]);
+    }
+
+    public static long hashKey(String... s){
+        return MurmurHash3.hash128x64(Arrays.asList(s).stream().collect(Collectors.joining("#")).getBytes())[0];
+    }
+
+    public static long domainKey(String caseId, String domain){
+        return hashKey(caseId, domain);
+    }
+}

--- a/cache/src/main/java/lt/tokenmill/crawling/cache/utils/KeyUtils.java
+++ b/cache/src/main/java/lt/tokenmill/crawling/cache/utils/KeyUtils.java
@@ -1,0 +1,22 @@
+package lt.tokenmill.crawling.cache.utils;
+
+import redis.clients.jedis.Jedis;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class KeyUtils {
+    public static boolean isWildCard(String key){
+        return key.contains("*");
+    }
+
+    public static Set<String> resolveKeys(String key, Jedis jedis){
+        if(isWildCard(key)){
+            return jedis.keys(key);
+        }
+        else{
+            return Arrays.asList(key).stream().collect(Collectors.toSet());
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <module>administration-ui</module>
         <module>analysis-ui</module>
         <module>ui-commons</module>
+        <module>cache</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
When storing temporary data, ElasticSearch can become bottleneck. Optionally, use Redis for that.